### PR TITLE
fix: use fetchFeedInfoList instead of FEED_INFO_LIST

### DIFF
--- a/src/cli/generate-feed-command.ts
+++ b/src/cli/generate-feed-command.ts
@@ -6,7 +6,7 @@ import { FeedGenerator } from '../feed/feed-generator.js';
 import { FeedStorer } from '../feed/feed-storer.js';
 import { FeedValidator } from '../feed/feed-validator.js';
 import { logger } from '../feed/logger.js';
-import { FEED_INFO_LIST } from '../resources/feed-info-list.js';
+import { fetchFeedInfoList } from '../resources/feed-info-list.js';
 
 const dirName = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -19,9 +19,12 @@ const feedValidator = new FeedValidator();
 const feedStorer = new FeedStorer();
 
 (async () => {
+  // JSer.infoのwatch-listからフィード情報を取得
+  const feedInfoList = await fetchFeedInfoList();
+
   // フィード取得
   const crawlFeedsResult = await feedCrawler.crawlFeeds(
-    FEED_INFO_LIST,
+    feedInfoList,
     constants.feedFetchConcurrency,
     constants.feedOgFetchConcurrency,
     new Date(Date.now() - constants.aggregateFeedDurationInHours * 60 * 60 * 1000),


### PR DESCRIPTION
PR #3でupstreamをマージした際に、FEED_INFO_LIST（企業テックブログ一覧）を 使用するようになってしまい、JSer.info独自のwatch-list
(https://jser.info/watch-list/data/opml-list.json) からフィードを取得する機能が失われていた。

fetchFeedInfoList()を使用するように修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 概要
<!--
どのような変更をしたか簡潔に記載してください

新規フィード追加の場合、以下が含まれていると確認が捗ります
- 企業名
- ブログURL
- RSSフィードURL
-->
