### PR TITLE
fix: handle empty feed items in lastModifiedBlogsDate.js

### DIFF
--- a/src/site/_data/lastModifiedBlogsDate.js
+++ b/src/site/_data/lastModifiedBlogsDate.js
@@ -2,5 +2,9 @@ export default async () => {
   const feedDataModule = await import('../feeds/feed.json');
   const feedData = feedDataModule.default;
 
+  if (!feedData.items || feedData.items.length === 0) {
+    return new Date().toISOString();
+  }
+
   return new Date(feedData.items[0].date_published).toISOString();
 };


### PR DESCRIPTION
原因: src/site/_data/lastModifiedBlogsDate.js:5 で feedData.items[0].date_published に直接アクセスしていますが、items が空配列の場合に TypeError: Cannot read properties of undefined (reading 'date_published') が発生します。

修正内容: 空配列チェックを追加し、空の場合は現在日時を返すようにしました。

根本原因の推測: CIでは1月2日 01:45 UTC に成功した後、同じコミットe63c8d0で連続して失敗しています。feed-generateは成功しているので、フィードの取得自体は動いていますが、おそらく何らかの理由で取得できた記事が0件になり、feed.jsonのitemsが空配列になっていると思われます。

考えられる原因:

jser.info/watch-list のデータに問題がある
外部フィードの取得でエラーが多発している
全ての記事が古すぎてフィルタリングされている
この修正により、空配列のエッジケースでもビルドがクラッシュしなくなります。

