### PR TITLE
fix: skip data URI favicons instead of rendering them

### DIFF
--- a/src/common/eleventy-utils.ts
+++ b/src/common/eleventy-utils.ts
@@ -57,7 +57,8 @@ export const imageIconShortcode = async (src: string, alt: string, pathPrefix = 
   }
 
   if (src.startsWith('data:')) {
-    return `<img src='${src}' alt='${alt}' loading='lazy' width='16' height='16'>`;
+    // data URI favicons are not supported (security + HTML parsing issues)
+    return alternativeImageTag;
   }
 
   const parsedUrl = url.parse(src);


### PR DESCRIPTION
data URI favicons cause HTML parsing issues and potential security concerns (injection). Simply skip them instead of trying to render.

## 概要
<!--
どのような変更をしたか簡潔に記載してください

新規フィード追加の場合、以下が含まれていると確認が捗ります
- 企業名
- ブログURL
- RSSフィードURL
-->
